### PR TITLE
Fixed setting tag_version in workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         file_version=$(cat gtr/VERSION)
-        echo ::set-output name=tag_version::${GITHUB_REF/refs\/tags\//}
+        tag_version=${GITHUB_REF#refs/*/}
         if test "$file_version" = "$tag_version";
         then
           echo "Versions match! >> $file_version"

--- a/gtr/main.py
+++ b/gtr/main.py
@@ -23,9 +23,9 @@ from gtr.recommender import (
 )
 
 logger = logging.getLogger("gtr")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
+ch.setLevel(logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)


### PR DESCRIPTION
- Fixed assigning the value of git tag to `tag_version`
- Changed logging level to DEBUG to have context for any errors in `Recommender.shuffle`