### PR TITLE
Added Bearer Auth, Rate Limiting, ...

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,6 +41,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -e .[dev]
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.2.0
+      with:
+        redis-version: 6
     - name: Run tox
       env:
         GENIUS_CLIENT_ID: ${{ secrets.GENIUS_CLIENT_ID }}
@@ -50,6 +54,8 @@ jobs:
         SPOTIFY_REDIRECT_URI: ${{ secrets.SPOTIFY_REDIRECT_URI }}
         SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
+        SECRET_KEY: TEST_KEY
+        REDIS_URL: redis://:@127.0.0.1:6379
       run: tox
 
     - name: Archive code coverage results

--- a/gtr/auth.py
+++ b/gtr/auth.py
@@ -1,0 +1,84 @@
+from json.decoder import JSONDecodeError
+from typing import Awaitable, Callable, List, Tuple, Union
+
+import jwt
+from fastapi.responses import JSONResponse
+from ratelimit import RateLimitMiddleware
+from ratelimit.types import Scope
+
+
+class EmptyInformation(Exception):  # noqa: B903
+    def __init__(self, scope: Scope, message: str = "") -> None:
+        self.scope = scope
+        self.message = message
+
+
+class BadInformation(Exception):  # noqa: B903
+    def __init__(self, scope: Scope, message: str = "") -> None:
+        self.scope = scope
+        self.message = message
+
+
+class CustomRateLimitMiddleware(RateLimitMiddleware):
+    async def __call__(self, scope, receive, send):
+        try:
+            await super().__call__(scope, receive, send)
+        except (BadInformation, EmptyInformation) as e:
+            response = JSONResponse(
+                status_code=401,
+                content={"detail": e.args[1]},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+
+
+def create_jwt_auth(
+    key: str,
+    algorithms: Union[List[str], str],
+) -> Callable[[Scope], Awaitable[Tuple[str, str]]]:
+    """JWT Authentication
+
+    from https://github.com/abersheeran/
+    asgi-ratelimit/blob/master/ratelimit/auths/jwt.py
+    """
+
+    async def jwt_auth(scope: Scope) -> Tuple[str, str]:
+        """
+        About jwt header, read this link:
+        """
+        for name, value in scope["headers"]:  # type: bytes, bytes
+            if name == b"authorization":
+                try:
+                    authorization = value.decode("utf8")
+                except JSONDecodeError:  # pragma: no cover
+                    raise BadInformation(scope, "Invalid token")
+                break
+        else:
+            authorization = None
+
+        if not authorization:
+            raise EmptyInformation(scope, "Unauthorized access")
+
+        bad_header = False
+        try:
+            token_type, json_web_token = authorization.split(" ")
+        except ValueError:
+            bad_header = True
+
+        if bad_header or token_type != "Bearer":
+            raise BadInformation(
+                scope,
+                "Authorization header must be `Bearer` type. Like: `Bearer token`",
+            )
+
+        try:
+            data = jwt.decode(json_web_token, key, algorithms=algorithms)
+        except jwt.InvalidTokenError:
+            raise BadInformation(scope, "Invalid token")
+
+        try:
+            return data["user"], data.get("group", "default")
+        except KeyError:
+            raise BadInformation(scope, "Invalid token")
+
+    return jwt_auth

--- a/gtr/auth.py
+++ b/gtr/auth.py
@@ -1,5 +1,6 @@
 from json.decoder import JSONDecodeError
 from typing import Awaitable, Callable, List, Tuple, Union
+from urllib.parse import parse_qs
 
 import jwt
 from fastapi.responses import JSONResponse
@@ -54,10 +55,11 @@ def create_jwt_auth(
                     raise BadInformation(scope, "Invalid token")
                 break
         else:
-            authorization = None
-
-        if not authorization:
-            raise EmptyInformation(scope, "Unauthorized access")
+            parameters = parse_qs(scope["query_string"])
+            token = parameters.get(b"access_token")
+            if token is None:
+                raise EmptyInformation(scope, "Unauthorized access")
+            authorization = f"Bearer {token[0].decode('utf8')}"
 
         bad_header = False
         try:

--- a/gtr/constants.py
+++ b/gtr/constants.py
@@ -7,3 +7,6 @@ LASTFM_API_KEY: str = os.environ["LASTFM_API_KEY"]
 SPOTIFY_CLIENT_ID: str = os.environ["SPOTIFY_CLIENT_ID"]
 SPOTIFY_CLIENT_SECRET: str = os.environ["SPOTIFY_CLIENT_SECRET"]
 SPOTIFY_REDIRECT_URI: str = os.environ["SPOTIFY_REDIRECT_URI"]
+SECRET_KEY: str = os.environ["SECRET_KEY"]
+REDIS_URL: str = os.environ["REDIS_URL"]
+HASH_ALGORITHM: str = "HS256"

--- a/gtr/main.py
+++ b/gtr/main.py
@@ -267,6 +267,18 @@ def search_artists(q: str = Query(..., title="Artist name", example="Eminem")):
 
 
 @app.get(
+    "/songs/len",
+    summary="Number of songs in the recommender",
+    response_model=Dict[str, int],
+    tags=["songs"],
+    response_description="Number of songs",
+)
+def len_songs():
+    """Get the number of songs available in the recommender."""
+    return {"len": recommender.num_songs}
+
+
+@app.get(
     "/songs/{id}",
     summary="Get a song",
     response_model=Dict[str, Song],

--- a/gtr/recommender.py
+++ b/gtr/recommender.py
@@ -411,7 +411,11 @@ class Recommender:
             hits = []
             for row in cosine_similarities:
                 id = selected[row[0]]
-                song = self.song(id)
+                try:
+                    song = self.song(id)
+                except IndexError:  # pragma: no cover
+                    logger.error("Index error for %d", id)
+                    continue
                 if is_valid(song):
                     hits.append(song)
                 if len(hits) == 5:
@@ -419,7 +423,11 @@ class Recommender:
         else:
             hits = []
             for index in selected:
-                song = self.song(index)
+                try:
+                    song = self.song(index)
+                except IndexError:  # pragma: no cover
+                    logger.error("Index error for %d", index)
+                    continue
                 if is_valid(song):
                     hits.append(song)
                 if len(hits) == 5:

--- a/gtr/recommender.py
+++ b/gtr/recommender.py
@@ -93,6 +93,7 @@ class Recommender:
             en.drop(columns=["download_url"]), fa, how="outer"
         )
         self.songs.replace({np.NaN: None}, inplace=True)
+        self.num_songs = len(self.songs)
 
         # Read artists
         logger.debug("Reading artists from CSV files")

--- a/gtr/recommender.py
+++ b/gtr/recommender.py
@@ -404,7 +404,7 @@ class Recommender:
                     .flatten()
                     .sum()
                 )
-                if artist.name.values[0] in user_artists_names:
+                if artist.name.values[0] in user_artists_names:  # pragma: no cover
                     cosine_similarity += 1
                 cosine_similarities.append((index, cosine_similarity))
             cosine_similarities.sort(key=lambda x: x[1], reverse=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gunicorn>=20.1.0,<20.2.0
 uvicorn[standard]==0.13.4
 uvloop==0.15.2
 httptools==0.1.1
+asgi-ratelimit[full]==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-fastapi>=0.63.0,<0.64.0
+fastapi==0.63.0
 git+https://github.com/allerter/LyricsGenius.git@fix-auth-init
 tekore>=3.6.1,<3.7.0
 pandas>=1.2.3,<1.3.0
-scikit-learn>=0.24.1,<0.25.0
+scikit-learn==0.24.1
 gunicorn>=20.1.0,<20.2.0
-uvicorn[standard]>=0.13.4,<0.14.0
-uvloop>=0.15.2,<0.16.0
-httptools>=0.1.1,<0.2.0
+uvicorn[standard]==0.13.4
+uvloop==0.15.2
+httptools==0.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,47 @@ import json
 import os
 from os.path import join
 
+import jwt
 import pytest
+from fastapi.testclient import TestClient
 
+from gtr.constants import SECRET_KEY
+from gtr.main import app
 from gtr.recommender import Recommender
 
 
 @pytest.fixture
 def assert_all_responses_were_requested() -> bool:
     return False
+
+
+@pytest.fixture(scope="session")
+def token():
+    return jwt.encode(
+        {"user": "test", "group": "unlimited"}, SECRET_KEY, "HS256"
+    ).decode("utf8")
+
+
+@pytest.fixture(scope="session")
+def default_token():
+    return jwt.encode({"user": "test", "group": "default"}, SECRET_KEY, "HS256").decode(
+        "utf8"
+    )
+
+
+@pytest.fixture(scope="session")
+def invalid_token():
+    return jwt.encode({"group": "unlimited"}, SECRET_KEY, "HS256").decode("utf8")
+
+
+@pytest.fixture(scope="session")
+def auth_header(token):
+    return {"Authorization": "Bearer {}".format(token)}
+
+
+@pytest.fixture(scope="session")
+def client():
+    return TestClient(app)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -269,6 +269,12 @@ class TestAPI:
         assert response.status_code == 200
         assert type(response_dict["len"]) is int
 
+    def test_auth_in_query(self, client, token):
+        response = client.get("/songs/len", params={"access_token": token})
+        response_dict = response.json()
+        assert response.status_code == 200
+        assert type(response_dict["len"]) is int
+
     def test_missing_auth(self, client):
         response = client.get("/", headers=None)
         response_dict = response.json()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,12 +3,8 @@ from unittest.mock import create_autospec, patch
 import lyricsgenius as lg
 import pytest
 import tekore as tk
-from fastapi.testclient import TestClient
 
-from gtr.main import app
 from gtr.recommender import Preferences, Recommender
-
-client = TestClient(app)
 
 
 def get_mock_coro(return_value):
@@ -19,75 +15,83 @@ def get_mock_coro(return_value):
 
 
 class TestAPI:
-    def test_read_root(self):
-        response = client.get("/")
+    def test_read_root(self, client, auth_header):
+        response = client.get("/", headers=auth_header)
         assert response.status_code == 200
         assert response.json() == {"status": "OK"}
 
-    def test_artist(self):
+    def test_artist(self, client, auth_header):
         artist_id = 1
-        response = client.get(f"/artists/{artist_id}")
+        response = client.get(f"/artists/{artist_id}", headers=auth_header)
         assert response.status_code == 200
         assert response.json()["artist"]["id"] == artist_id
 
-    def test_artist_missing_id(self):
+    def test_artist_missing_id(self, client, auth_header):
         artist_id = 99999999999
-        response = client.get(f"/artists/{artist_id}")
+        response = client.get(f"/artists/{artist_id}", headers=auth_header)
         assert response.status_code == 404
         assert response.json().get("artist") is None
 
-    def test_artists(self):
+    def test_artists(self, client, auth_header):
         artist_ids = [1, 2, 3]
         response = client.get(
-            "/artists", params={"ids": ",".join(str(x) for x in artist_ids)}
+            "/artists",
+            params={"ids": ",".join(str(x) for x in artist_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 200
         for i, artist_id in enumerate(artist_ids):
             assert response_dict["artists"][i]["id"] == artist_id
 
-    def test_artists_bad_id_type(self):
+    def test_artists_bad_id_type(self, client, auth_header):
         artist_ids = [1, 2, "_3"]
         response = client.get(
-            "/artists", params={"ids": ",".join(str(x) for x in artist_ids)}
+            "/artists",
+            params={"ids": ",".join(str(x) for x in artist_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("artists") is None
 
-    def test_artists_over_limit(self):
+    def test_artists_over_limit(self, client, auth_header):
         artist_ids = [x for x in range(11)]
         response = client.get(
-            "/artists", params={"ids": ",".join(str(x) for x in artist_ids)}
+            "/artists",
+            params={"ids": ",".join(str(x) for x in artist_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("artists") is None
 
-    def test_artists_missing_id(self):
+    def test_artists_missing_id(self, client, auth_header):
         artist_ids = [1, 999999999999, 2]
         response = client.get(
-            "/artists", params={"ids": ",".join(str(x) for x in artist_ids)}
+            "/artists",
+            params={"ids": ",".join(str(x) for x in artist_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 404
         assert response_dict.get("artists") is None
 
-    def test_genres(self, recommender):
-        response = client.get("/genres")
+    def test_genres(self, client, auth_header, recommender):
+        response = client.get("/genres", headers=auth_header)
         response_dict = response.json()
         assert response.status_code == 200
         assert len(response_dict["genres"]) == len(recommender.genres)
 
-    def test_genres_with_age(self, recommender):
-        response = client.get("/genres", params={"age": 20})
+    def test_genres_with_age(self, client, auth_header, recommender):
+        response = client.get("/genres", params={"age": 20}, headers=auth_header)
         response_dict = response.json()
         assert response.status_code == 200
         assert response_dict["genres"] == recommender.genres_by_age(20)
 
     @pytest.mark.parametrize("platform", ["genius", "spotify"])
     @pytest.mark.parametrize("result", [Preferences(genres=["pop"], artists=[]), None])
-    def test_preferences_from_platform(self, platform, result):
+    def test_preferences_from_platform(self, client, auth_header, platform, result):
         recommender = create_autospec(Recommender)
         recommender.preferences_from_platform.return_value = result
         # Mock genius and spotify token responses
@@ -106,7 +110,9 @@ class TestAPI:
             "gtr.main.genius_auth", OAuth2
         ), patch("gtr.main.spotify_auth", RefreshingCredentials):
             response = client.get(
-                "/preferences", params={f"{platform}_code": "test_code"}
+                "/preferences",
+                params={f"{platform}_code": "test_code"},
+                headers=auth_header,
             )
         response_dict = response.json()
 
@@ -117,15 +123,15 @@ class TestAPI:
             assert response_dict["preferences"]["genres"] == []
             assert response_dict["preferences"]["artists"] == []
 
-    def test_preferences_from_platform_no_code(self):
-        response = client.get("/preferences")
+    def test_preferences_from_platform_no_code(self, client, auth_header):
+        response = client.get("/preferences", headers=auth_header)
         response_dict = response.json()
 
         assert response.status_code == 400
         assert response_dict.get("preferences") is None
 
     @pytest.mark.parametrize("platform", ["genius", "spotify"])
-    def test_preferences_from_platform_no_token(self, platform):
+    def test_preferences_from_platform_no_token(self, client, auth_header, platform):
         # Mock genius and spotify token responses
         if platform == "genius":
             OAuth2 = create_autospec(lg.OAuth2)
@@ -142,7 +148,9 @@ class TestAPI:
             "gtr.main.spotify_auth", RefreshingCredentials
         ):
             response = client.get(
-                "/preferences", params={f"{platform}_code": "test_code"}
+                "/preferences",
+                params={f"{platform}_code": "test_code"},
+                headers=auth_header,
             )
         response_dict = response.json()
 
@@ -150,94 +158,140 @@ class TestAPI:
         assert response_dict.get("preferences") is None
 
     @pytest.mark.parametrize("artists", [None, "", "Eminem,Blackbear"])
-    def test_recommendations(self, artists):
+    def test_recommendations(self, client, auth_header, artists):
         response = client.get(
-            "/recommendations", params={"genres": "pop,rock", "artists": artists}
+            "/recommendations",
+            params={"genres": "pop,rock", "artists": artists},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 200
         assert isinstance(response_dict["recommendations"], list)
 
-    def test_recommendations_empty_genres(self):
-        response = client.get("/recommendations", params={"genres": "", "artists": ""})
-        response_dict = response.json()
-        assert response.status_code == 400
-        assert response_dict.get("recommendations") is None
-
-    def test_recommendations_missing_genres(self):
-        response = client.get("/recommendations", params={"artists": "Eminem"})
-        response_dict = response.json()
-        assert response.status_code == 400
-        assert response_dict.get("recommendations") is None
-
-    def test_recommendations_invalid_genres(self):
+    def test_recommendations_empty_genres(self, client, auth_header):
         response = client.get(
-            "/recommendations", params={"genres": "invalid,pop", "artists": ""}
+            "/recommendations",
+            params={"genres": "", "artists": ""},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("recommendations") is None
 
-    def test_recommendations_invalid_artists(self):
+    def test_recommendations_missing_genres(self, client, auth_header):
+        response = client.get(
+            "/recommendations", params={"artists": "Eminem"}, headers=auth_header
+        )
+        response_dict = response.json()
+        assert response.status_code == 400
+        assert response_dict.get("recommendations") is None
+
+    def test_recommendations_invalid_genres(self, client, auth_header):
+        response = client.get(
+            "/recommendations",
+            params={"genres": "invalid,pop", "artists": ""},
+            headers=auth_header,
+        )
+        response_dict = response.json()
+        assert response.status_code == 400
+        assert response_dict.get("recommendations") is None
+
+    def test_recommendations_invalid_artists(self, client, auth_header):
         response = client.get(
             "/recommendations",
             params={"genres": "pop", "artists": "Eminem,invalid"},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("recommendations") is None
 
-    def test_search_artist(self):
+    def test_search_artist(self, client, auth_header):
         name = "Eminem"
-        response = client.get("/search/artists", params={"q": name})
+        response = client.get(
+            "/search/artists", params={"q": name}, headers=auth_header
+        )
         response_dict = response.json()
         assert response.status_code == 200
         assert response_dict["hits"][0]["name"] == name
 
-    def test_song(self):
+    def test_song(self, client, auth_header):
         song_id = 1
-        response = client.get(f"/songs/{song_id}")
+        response = client.get(f"/songs/{song_id}", headers=auth_header)
         response_dict = response.json()
         assert response.status_code == 200
         assert response_dict["song"]["id"] == song_id
 
-    def test_song_missing_id(self):
+    def test_song_missing_id(self, client, auth_header):
         song_id = 99999999999
-        response = client.get(f"/songs/{song_id}")
+        response = client.get(f"/songs/{song_id}", headers=auth_header)
         response_dict = response.json()
         assert response.status_code == 404
         assert response_dict.get("song") is None
 
-    def test_songs(self):
+    def test_songs(self, client, auth_header):
         song_ids = [1, 2, 3]
         response = client.get(
-            "/songs", params={"ids": ",".join(str(x) for x in song_ids)}
+            "/songs",
+            params={"ids": ",".join(str(x) for x in song_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 200
         for i, song_id in enumerate(song_ids):
             assert response_dict["songs"][i]["id"] == song_id
 
-    def test_songs_missing_id(self):
+    def test_songs_missing_id(self, client, auth_header):
         song_ids = [1, 2, 99999999999]
         response = client.get(
-            "/songs", params={"ids": ",".join(str(x) for x in song_ids)}
+            "/songs",
+            params={"ids": ",".join(str(x) for x in song_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 404
         assert response_dict.get("songs") is None
 
-    def test_songs_over_limit(self):
+    def test_songs_over_limit(self, client, auth_header):
         song_ids = [x for x in range(11)]
         response = client.get(
-            "/songs", params={"ids": ",".join(str(x) for x in song_ids)}
+            "/songs",
+            params={"ids": ",".join(str(x) for x in song_ids)},
+            headers=auth_header,
         )
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("songs") is None
 
-    def test_len_songs(self):
-        response = client.get("/songs/len")
+    def test_len_songs(self, client, auth_header):
+        response = client.get("/songs/len", headers=auth_header)
         response_dict = response.json()
         assert response.status_code == 200
         assert type(response_dict["len"]) is int
+
+    def test_missing_auth(self, client):
+        response = client.get("/", headers=None)
+        response_dict = response.json()
+        assert type(response_dict) is dict
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        "auth_type", ["", "Bearer ", "Bearer _", "Bearer", "bearer "]
+    )
+    def test_invalid_auth(self, client, auth_type, invalid_token):
+        response = client.get("/", headers={"Authorization": auth_type + invalid_token})
+        response_dict = response.json()
+        assert type(response_dict) is dict
+        assert response.status_code == 401
+
+    def test_too_many_requests(self, client, default_token):
+        # limit for path "/" for default user group is 5/second
+        for i in range(6):
+            response = client.get(
+                "/", headers={"Authorization": f"Bearer {default_token}"}
+            )
+            print("res: ", response.headers)
+            if i < 5:
+                assert response.status_code == 200
+            else:
+                assert response.status_code == 429

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,7 +150,7 @@ class TestAPI:
         assert response.status_code == 400
         assert response_dict.get("preferences") is None
 
-    @pytest.mark.parametrize("artists", ["", "Eminem,Blackbear"])
+    @pytest.mark.parametrize("artists", [None, "", "Eminem,Blackbear"])
     def test_recommendations(self, artists):
         response = client.get(
             "/recommendations", params={"genres": "pop,rock", "artists": artists}
@@ -159,14 +159,14 @@ class TestAPI:
         assert response.status_code == 200
         assert isinstance(response_dict["recommendations"], list)
 
-    def test_recommendations_missing_artists(self):
-        response = client.get("/recommendations", params={"genres": "pop"})
+    def test_recommendations_empty_genres(self):
+        response = client.get("/recommendations", params={"genres": "", "artists": ""})
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("recommendations") is None
 
-    def test_recommendations_no_genres(self):
-        response = client.get("/recommendations", params={"genres": "", "artists": ""})
+    def test_recommendations_missing_genres(self):
+        response = client.get("/recommendations", params={"artists": "Eminem"})
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("recommendations") is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, Mock, create_autospec, patch
+from unittest.mock import create_autospec, patch
 
 import lyricsgenius as lg
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,3 +235,9 @@ class TestAPI:
         response_dict = response.json()
         assert response.status_code == 400
         assert response_dict.get("songs") is None
+
+    def test_len_songs(self):
+        response = client.get("/songs/len")
+        response_dict = response.json()
+        assert response.status_code == 200
+        assert type(response_dict["len"]) is int

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ command_line = -m pytest
 
 [coverage:report]
 exclude_lines =
+    pragma: no cover
     def is_valid
     if artist.name.values[0] in user_artists_names
     __repr__

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,9 @@ command_line = -m pytest
 exclude_lines =
     pragma: no cover
     def is_valid
-    if artist.name.values[0] in user_artists_names
     __repr__
     if __name__ == "__main__"
-fail_under = 0.90
+fail_under = 1
 precision = 1
 show_missing = True
 skip_covered = True


### PR DESCRIPTION
- Added Bearer authentication. Either through providing an access token in the query parameter `access_token` or in the `Authorization` header with the value `Bearer TOKEN`.
- Added rate limiting based on user groups. Currently, there are only two user groups: default and unlimited. Default users have rate limiting and unlimited users aren't limited. Authentication is required nevertheless. Rate limiting is done through a middleware using a Redis backend.
- The `artists` parameter for `/recommendations` is now optional. Providing an empty one or not providing it at all won't make a difference.
- Catch sporadic index exceptions in `Recommender.shuffle` for investigation and reliability.
- Pinned requirements that are in beta to exact versions.
- Coverage now fails if under 100%.
- Added and updated tests.