### PR TITLE
Updated preferences_from_platform, ...

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,6 +36,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    - name: Cache Pip dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/gtr/constants.py
+++ b/gtr/constants.py
@@ -1,12 +1,6 @@
 import os
 
-GENIUS_CLIENT_ID: str = os.environ["GENIUS_CLIENT_ID"]
-GENIUS_CLIENT_SECRET: str = os.environ["GENIUS_CLIENT_SECRET"]
-GENIUS_REDIRECT_URI: str = os.environ["GENIUS_REDIRECT_URI"]
 LASTFM_API_KEY: str = os.environ["LASTFM_API_KEY"]
-SPOTIFY_CLIENT_ID: str = os.environ["SPOTIFY_CLIENT_ID"]
-SPOTIFY_CLIENT_SECRET: str = os.environ["SPOTIFY_CLIENT_SECRET"]
-SPOTIFY_REDIRECT_URI: str = os.environ["SPOTIFY_REDIRECT_URI"]
 SECRET_KEY: str = os.environ["SECRET_KEY"]
 REDIS_URL: str = os.environ["REDIS_URL"]
 HASH_ALGORITHM: str = "HS256"

--- a/gtr/main.py
+++ b/gtr/main.py
@@ -196,36 +196,18 @@ def genres(
     response_description="Preferences object",
 )
 async def preferences_from_platform(
-    genius_code: Optional[str] = None, spotify_code: Optional[str] = None
+    token: str,
+    platform: str = Query(..., regex="^(spotify|genius)$"),
 ):
     """Get user preferences (genres and artists)
     based on user's activity on platform.
     """
-    if not any((genius_code, spotify_code)):
-        raise HTTPException(
-            status_code=400,
-            detail="No code provided.",
-        )
-    elif genius_code:
-        token = genius_auth.get_user_token(code=genius_code)
-        platform = "genius"
-    else:
-        token = await spotify_auth.request_user_token(spotify_code)
-        token = token.access_token
-        platform = "spotify"
-
-    if token is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Failed to get the token.",
-        )
-    else:
-        pref = await recommender.preferences_from_platform(token, platform)
-        return {
-            "preferences": pref
-            if pref is not None
-            else Preferences(genres=[], artists=[])
-        }
+    pref = await recommender.preferences_from_platform(token, platform)
+    return {
+        "preferences": pref
+        if pref is not None
+        else Preferences(genres=[], artists=[])
+    }
 
 
 @app.get(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ uvicorn[standard]==0.13.4
 uvloop==0.15.2
 httptools==0.1.1
 asgi-ratelimit[full]==0.4.0
+httpx>=0.17.1,<0.18.0


### PR DESCRIPTION
- Parameteres of the `preferences_from_platform` endpoint were replaced with `platform` (value either `spotify` or `genius`) and `token`. 
- Added validating supplied token to `preferences_from_platform`. `httpx` was added to requirements to send async requests to Genius.
- Added caching `pip` dependencies in GitHub workflow.